### PR TITLE
New false positive testing.

### DIFF
--- a/passoff/TrieTest.java
+++ b/passoff/TrieTest.java
@@ -18,7 +18,7 @@ public class TrieTest {
 
     private static final String trieString = "baboon\ncar\ncares\ncaress";
     private static final String wrongTrieString = "baboon\ncar\ncar\ncares\ncaress";
-    private static final String FILENAME = "dictionaryFiles/notsobig.txt";
+    private static final String FILENAME = "notsobig.txt";
     private ITrie studentTrie;
     private ITrie studentTrie2;
 

--- a/passoff/TrieTest.java
+++ b/passoff/TrieTest.java
@@ -18,7 +18,7 @@ public class TrieTest {
 
     private static final String trieString = "baboon\ncar\ncares\ncaress";
     private static final String wrongTrieString = "baboon\ncar\ncar\ncares\ncaress";
-    private static final String FILENAME = "notsobig.txt";
+    private static final String FILENAME = "dictionaryFiles/notsobig.txt";
     private ITrie studentTrie;
     private ITrie studentTrie2;
 
@@ -117,6 +117,14 @@ public class TrieTest {
         studentTrie.add("jackblanco");
         assertNotEquals(studentTrie, studentTrie2, "Two un-equal branching tries found equal.");
         assertNotEquals(studentTrie2, studentTrie, "Two un-equal branching tries found equal.");
+
+        clearTries();
+
+        add("at");
+        studentTrie.add("cat");
+        studentTrie2.add("car");
+        add("zip");
+        assertNotEquals(studentTrie, studentTrie2, "Unequal tries with equal counts found equal.");
     }
 
     @Test
@@ -235,5 +243,10 @@ public class TrieTest {
     private void add(String word){
         studentTrie.add(word);
         studentTrie2.add(word);
+    }
+
+    private void clearTries() {
+        studentTrie = new Trie();
+        studentTrie2 = new Trie();
     }
 }


### PR DESCRIPTION
Last semester, I noticed our tests never checked unequal tries with equal counts, so a student's starter equals method could pass the tests with no recursive helper needed simply by checking wordCount and nodeCount. The new test case I've added checks for that, as well as the cases where a student returns on the first non-null child and where a student doesn't return false immediately on unequal children.
This should patch all known holes in TrieTest.